### PR TITLE
Update builds.go Death Touch Azazel

### DIFF
--- a/builds.go
+++ b/builds.go
@@ -50,6 +50,9 @@ var (
 
 			// The piercing shots do nothing for the bone club.
 			"Tainted Forgotten", // 35
+			
+			// The piercing shots do nothing for Azazel's Brimstone.
+			"Azazel", // 7
 		},
 
 		// #5 - Dr. Fetus


### PR DESCRIPTION
Adding Azazel to antisynergies with Death Touch for same reason as both Forgottens.